### PR TITLE
feat(analytics): track SPA page views and key product events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@trpc/next": "^11.17.0",
         "@trpc/react-query": "^11.17.0",
         "@trpc/server": "^11.17.0",
+        "@vercel/analytics": "^2.0.1",
         "@vercel/blob": "^2.4.0",
         "bcrypt": "^5.1.1",
         "daisyui": "^5.5.20",
@@ -3174,6 +3175,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vercel/blob": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@trpc/next": "^11.17.0",
     "@trpc/react-query": "^11.17.0",
     "@trpc/server": "^11.17.0",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.4.0",
     "bcrypt": "^5.1.1",
     "daisyui": "^5.5.20",

--- a/src/components/GuestImport.tsx
+++ b/src/components/GuestImport.tsx
@@ -49,6 +49,9 @@ export function GuestImport() {
             const entries = readLocalProgress();
             if (entries.length > 0) {
                 progressForUserRef.current = userId;
+                // A guest who'd been typing locally just signed in — the conversion
+                // moment. Local progress is cleared on import, so this fires once.
+                window.gtag?.("event", "guest_signup", { tests: entries.length });
                 syncProgress.mutate({ entries, utcOffsetMinutes: -new Date().getTimezoneOffset() });
             }
         }

--- a/src/components/typer/Typer.tsx
+++ b/src/components/typer/Typer.tsx
@@ -374,6 +374,13 @@ export const Typer = (props: TyperProps) => {
         const finalStats = getStats(finalCharacterCount, finalIncorrectCount)
         const completion = buildCompletion(finalStats, finalCharacterCount, finalIncorrectCount)
 
+        window.gtag?.("event", "test_completed", {
+            mode,
+            wpm: Math.round(finalStats.netWpm),
+            accuracy: Math.round(finalStats.accuracy),
+            signed_in: !!sessionData?.user,
+        })
+
         if (mode === TestModes.normal || mode === TestModes.quotes) {
             if (
                 levelRequirements &&

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,14 +11,35 @@ import { store } from '../state/store';
 import { Provider } from 'react-redux';
 import Head from "next/head";
 import Script from "next/script";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { Analytics } from "@vercel/analytics/next"
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
 
 const MyApp: AppType<{ session: Session | null }> = ({
   Component,
   pageProps: { session, ...pageProps },
 }) => {
+  const router = useRouter();
+
+  // GA4 only fires page_view on first load; SPA route changes need a manual hit.
+  useEffect(() => {
+    const onRouteChange = (url: string) => {
+      window.gtag?.("event", "page_view", { page_path: url });
+    };
+    router.events.on("routeChangeComplete", onRouteChange);
+    return () => router.events.off("routeChangeComplete", onRouteChange);
+  }, [router.events]);
+
   return (
     <Provider store={store}>
       <SessionProvider session={session}>
+        <Analytics/>
         <GuestImport />
         <Layout>
           <Head>

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -205,6 +205,8 @@ const Learn: NextPage = () => {
         const completedLevel = levels.find(item => item.name == levelName) ?? level
         const { stars, entry } = gradeResult(completedLevel, difficulty, { netWpm: result.netWpm, accuracy: result.accuracy })
 
+        window.gtag?.("event", "learn_lesson_done", { level: levelName, difficulty, stars })
+
         if (stars === 0) {
             showCompletion(result)
             return


### PR DESCRIPTION
GA4 only fires page_view on first load, so Next's client-side route changes went unrecorded. Fire a manual page_view on routeChangeComplete, and add custom events for the moments that matter:

- test_completed (all modes, guest + signed-in) with wpm/accuracy
- guest_signup at the guest->account conversion (progress import)
- learn_lesson_done with level/difficulty/stars

Also adds @vercel/analytics. Verified: npx tsc --noEmit clean.