### PR TITLE
fix(transitions): ignore untrackable letter pairs

### DIFF
--- a/src/lib/drillableTransitions.ts
+++ b/src/lib/drillableTransitions.ts
@@ -1,0 +1,24 @@
+import english1k from "~/components/typer/languages/english1k.json"
+
+export const MIN_REAL_TRANSITION_WORDS = 2
+
+const transitionWordCounts = new Map<string, number>()
+
+for (const word of english1k.words) {
+    const pairs = new Set<string>()
+    for (let i = 0; i < word.length - 1; i += 1) {
+        pairs.add(word.slice(i, i + 2))
+    }
+    for (const pair of pairs) {
+        transitionWordCounts.set(pair, (transitionWordCounts.get(pair) ?? 0) + 1)
+    }
+}
+
+export function realTransitionWordCount(pair: string): number {
+    return transitionWordCounts.get(pair.toLowerCase()) ?? 0
+}
+
+export function isTrackableTransitionPair(pair: string): boolean {
+    const normalized = pair.toLowerCase()
+    return /^[a-z]{2}$/.test(normalized) && realTransitionWordCount(normalized) >= MIN_REAL_TRANSITION_WORDS
+}

--- a/src/lib/transitions.test.ts
+++ b/src/lib/transitions.test.ts
@@ -26,6 +26,14 @@ describe("aggregateTransitions", () => {
         const evts = events([["a", 0], [" ", 100], ["b", 100], [".", 100], ["c", 100]])
         expect(aggregateTransitions(evts)).toEqual([])
     })
+
+    it("drops letter pairs that cannot be drilled with real transition words", () => {
+        const evts = events([["x", 0], ["i", 240], ["b", 120], ["r", 300]])
+        const aggs = aggregateTransitions(evts)
+
+        expect(aggs.find((a) => a.pair === "xi")).toBeUndefined()
+        expect(aggs.find((a) => a.pair === "br")).toMatchObject({ pair: "br", count: 1, totalMs: 300 })
+    })
 })
 
 describe("overallTransitionMeanMs", () => {
@@ -33,6 +41,7 @@ describe("overallTransitionMeanMs", () => {
         const aggs = [
             { pair: "th", count: 2, totalMs: 500, errors: 0 },
             { pair: "he", count: 2, totalMs: 300, errors: 0 },
+            { pair: "xi", count: 10, totalMs: 10_000, errors: 0 },
         ]
         expect(overallTransitionMeanMs(aggs)).toBe(200) // 800 / 4
     })
@@ -66,6 +75,17 @@ describe("worstTransitions", () => {
         expect(worstTransitions(aggs).find((t) => t.pair === "qz")).toBeUndefined()
     })
 
+    it("ignores stale untrackable pairs even when they are recurring and slow", () => {
+        const aggs = [
+            { pair: "xi", count: 20, totalMs: 20_000, errors: 0 },
+            { pair: "br", count: 10, totalMs: 4000, errors: 0 },
+            { pair: "th", count: 10, totalMs: 1000, errors: 0 },
+            { pair: "he", count: 10, totalMs: 1200, errors: 0 },
+        ]
+
+        expect(worstTransitions(aggs).map((t) => t.pair)).toEqual(["br"])
+    })
+
     it("returns nothing with no data", () => {
         expect(worstTransitions([])).toEqual([])
     })
@@ -74,11 +94,12 @@ describe("worstTransitions", () => {
 describe("mergeTransitions", () => {
     it("sums aggregates by pair", () => {
         const merged = mergeTransitions(
-            [{ pair: "th", count: 2, totalMs: 400, errors: 1 }],
+            [{ pair: "th", count: 2, totalMs: 400, errors: 1 }, { pair: "xi", count: 8, totalMs: 8000, errors: 0 }],
             [{ pair: "th", count: 3, totalMs: 600, errors: 0 }, { pair: "he", count: 1, totalMs: 100, errors: 0 }],
         )
         const th = merged.find((a) => a.pair === "th")!
         expect(th).toMatchObject({ count: 5, totalMs: 1000, errors: 1 })
         expect(merged.find((a) => a.pair === "he")!.count).toBe(1)
+        expect(merged.find((a) => a.pair === "xi")).toBeUndefined()
     })
 })

--- a/src/lib/transitions.ts
+++ b/src/lib/transitions.ts
@@ -4,6 +4,7 @@
 // single test's timeline (to sync) and over a user's lifetime rows (to surface).
 
 import type { KeystrokeEvent } from "./keystrokes"
+import { isTrackableTransitionPair } from "./drillableTransitions"
 
 // A pair recurs this many times in the lifetime data before its slowness is
 // signal rather than a fluke.
@@ -35,6 +36,7 @@ export function aggregateTransitions(events: KeystrokeEvent[]): TransitionAggreg
         const to = events[i]!.key.toLowerCase()
         if (!isLetter(from) || !isLetter(to)) continue
         const pair = from + to
+        if (!isTrackableTransitionPair(pair)) continue
         const dt = Math.max(events[i]!.t - events[i - 1]!.t, 0)
         const entry = byPair.get(pair) ?? { pair, count: 0, totalMs: 0, errors: 0 }
         entry.count += 1
@@ -62,6 +64,7 @@ export function overallTransitionMeanMs(aggregates: TransitionAggregate[]): numb
     let totalMs = 0
     let count = 0
     for (const a of aggregates) {
+        if (!isTrackableTransitionPair(a.pair)) continue
         totalMs += a.totalMs
         count += a.count
     }
@@ -75,13 +78,15 @@ export function worstTransitions(aggregates: TransitionAggregate[], limit = 5): 
     if (baseline <= 0) return []
 
     return aggregates
+        .filter((a) => isTrackableTransitionPair(a.pair))
         .filter((a) => a.count >= TRANSITION_MIN_COUNT)
         .map((a) => {
+            const pair = a.pair.toLowerCase()
             const meanMs = a.totalMs / a.count
             return {
-                pair: a.pair,
-                from: a.pair[0]!,
-                to: a.pair[1]!,
+                pair,
+                from: pair[0]!,
+                to: pair[1]!,
                 meanMs,
                 count: a.count,
                 ratio: meanMs / baseline,
@@ -99,11 +104,13 @@ export function mergeTransitions(existing: TransitionAggregate[], incoming: Tran
     const byPair = new Map<string, TransitionAggregate>()
     for (const a of [...existing, ...incoming]) {
         if (a.count <= 0) continue
-        const entry = byPair.get(a.pair) ?? { pair: a.pair, count: 0, totalMs: 0, errors: 0 }
+        const pair = a.pair.toLowerCase()
+        if (!isTrackableTransitionPair(pair)) continue
+        const entry = byPair.get(pair) ?? { pair, count: 0, totalMs: 0, errors: 0 }
         entry.count += a.count
         entry.totalMs += a.totalMs
         entry.errors += a.errors
-        byPair.set(a.pair, entry)
+        byPair.set(pair, entry)
     }
     return Array.from(byPair.values())
 }

--- a/src/server/api/routers/transitionStats.ts
+++ b/src/server/api/routers/transitionStats.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { Prisma } from "~/generated/prisma/client";
+import { isTrackableTransitionPair } from "~/lib/drillableTransitions";
 
 const transitionInput = z.object({
   pair: z.string().length(2),
@@ -23,13 +24,16 @@ export const transitionStatsRouter = createTRPCRouter({
   batchSync: protectedProcedure
     .input(z.object({ stats: z.array(transitionInput) }))
     .mutation(async ({ ctx, input }) => {
-      if (input.stats.length === 0) return { count: 0 };
+      const stats = input.stats
+        .map((stat) => ({ ...stat, pair: stat.pair.toLowerCase() }))
+        .filter((stat) => isTrackableTransitionPair(stat.pair));
+      if (stats.length === 0) return { count: 0 };
       const userId = ctx.session.user.id;
 
       // One bulk upsert, not N round-trips: a real test yields 100+ distinct
       // pairs, which overran the 5s interactive-transaction budget on the pooled
       // remote DB. INSERT ... ON CONFLICT increments in a single statement.
-      const rows = input.stats.map(
+      const rows = stats.map(
         (s) => Prisma.sql`(gen_random_uuid()::text, ${userId}, ${s.pair}, ${s.count}, ${s.totalMs}, ${s.errors}, NOW())`,
       );
       await ctx.prisma.$executeRaw`
@@ -42,6 +46,6 @@ export const transitionStatsRouter = createTRPCRouter({
           "updatedAt" = NOW()
       `;
 
-      return { count: input.stats.length };
+      return { count: stats.length };
     }),
 });

--- a/tests/e2e/helpers/trpc.ts
+++ b/tests/e2e/helpers/trpc.ts
@@ -10,6 +10,7 @@ interface MockTrpcOptions {
   invalidShare?: boolean;
   // Per-key practice stats for the /progress lifetime heatmap.
   keyStats?: { character: string; total: number; correct: number }[];
+  transitionStats?: { pair: string; count: number; totalMs: number; errors: number }[];
   // Make the progress history flat (a plateau) instead of rising.
   flatProgress?: boolean;
   // Mix timed and words records so /progress filter tests can prove scoping.
@@ -331,6 +332,7 @@ function responseForProcedure(procedure: string, input: ProcedureInput, options:
       return options.keyStats ?? [];
     case "transitionStats.get":
       if (options.emptyScores) return [];
+      if (options.transitionStats) return options.transitionStats;
       return [
         { pair: "br", count: 12, totalMs: 4800, errors: 3 }, // 400ms mean, 25% errors
         { pair: "th", count: 30, totalMs: 3000, errors: 0 }, // 100ms

--- a/tests/e2e/profile-auth.spec.ts
+++ b/tests/e2e/profile-auth.spec.ts
@@ -60,6 +60,22 @@ test.describe("authenticated profile", () => {
     await expect(page.locator("#confirmModal")).not.toBeChecked();
   });
 
+  test("does not surface stale untrackable transitions in profile coach tabs", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name.includes("mobile"), "Rail coach tabs are desktop-only off home.");
+    await mockAuthenticatedSession(page);
+    await mockTrpc(page, {
+      transitionStats: [
+        { pair: "xi", count: 30, totalMs: 18_000, errors: 0 },
+      ],
+    });
+
+    await page.goto("/profile");
+
+    await expect(page.getByTestId("profile-typing-style")).toBeVisible();
+    await expect(page.getByTestId("home-coach-tab-drill")).toHaveCount(0);
+    await expect(page.getByText("x->i")).toHaveCount(0);
+  });
+
   test("removes an existing custom profile picture", async ({ page }) => {
     await mockAuthenticatedSession(page, blobAvatarUrl);
     await mockTrpc(page, { profileImage: blobAvatarUrl });


### PR DESCRIPTION
Filter transition analytics to pairs that can be drilled with real words from the default drill corpus. This prevents stale or newly collected pairs such as x->i from surfacing on profile/progress coach tabs, and filters unsupported pairs during server sync.\n\nVerified: npx vitest run src/lib/transitions.test.ts; npx playwright test tests/e2e/profile-auth.spec.ts --project=desktop-chromium; npx vitest run; npm run build:check.