### PR TITLE
fix: - pressing shift should also toggle shift off/on label

### DIFF
--- a/src/components/home/HomeCoachTabs.tsx
+++ b/src/components/home/HomeCoachTabs.tsx
@@ -134,7 +134,8 @@ export function HomeCoachTabs({ className = "", desktop = true, inline = true }:
     const [challengeDismissed, setChallengeDismissed] = useState(false);
 
     useEffect(() => {
-        setDateKey(challengeDateKey(new Date(), -new Date().getTimezoneOffset()));
+        // Synced UTC day boundary — must match the challenge page (src/pages/challenge.tsx).
+        setDateKey(challengeDateKey(new Date()));
     }, []);
 
     useEffect(() => {

--- a/src/components/typer/Keyboard.tsx
+++ b/src/components/typer/Keyboard.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { addAlert } from "~/state/alert/alertSlice";
 import { TestModes } from "./types";
 import { useDispatch } from "react-redux";
@@ -27,8 +26,8 @@ interface KeyboardProps {
     baseAttemptsRef?: React.MutableRefObject<Map<string, { attempts: number, correct: number }>>,
     attemptVersion?: number,
     highlightKeys?: string[],
-    // Practice: the sticky shift-layer toggle now lives in the settings line above
-    // the test, so the page owns it; hold-to-peek stays internal.
+    // Practice: the combined shift-layer state (sticky settings-line toggle OR a
+    // held-Shift peek) — both owned by the page so the label and board stay in sync.
     shiftToggle?: boolean,
 }
 
@@ -39,30 +38,9 @@ export const Keyboard = (props: KeyboardProps) => {
     const dispatch = useDispatch()
 
     // Shift layer flips every cell to its shifted twin (R, ?, !, :) to read those
-    // accuracies separately. Two ways in: the sticky settings-line toggle (owned by
-    // the page), or holding Shift to peek (release returns to base). Hold-to-peek
-    // rather than a key toggle so typing a shifted glyph mid-test can't leave the
-    // layer stuck flipped.
-    const [shiftHeld, setShiftHeld] = useState(false)
-    const shiftLayer = shiftToggle || shiftHeld
-
-    useEffect(() => {
-        if (mode !== TestModes.practice) return
-        const onDown = (e: KeyboardEvent) => {
-            if (e.key !== "Shift" || e.repeat) return
-            setShiftHeld(true)
-        }
-        const onUp = (e: KeyboardEvent) => { if (e.key === "Shift") setShiftHeld(false) }
-        const clear = () => setShiftHeld(false)
-        window.addEventListener("keydown", onDown)
-        window.addEventListener("keyup", onUp)
-        window.addEventListener("blur", clear)
-        return () => {
-            window.removeEventListener("keydown", onDown)
-            window.removeEventListener("keyup", onUp)
-            window.removeEventListener("blur", clear)
-        }
-    }, [mode])
+    // accuracies separately. The page owns the combined state (sticky toggle OR a
+    // held-Shift peek), passed in as `shiftToggle`.
+    const shiftLayer = shiftToggle
 
     // Lock badges read off the active layer, so every not-enabled cell shows locked.
     // Base layer: any physical key not in the drill set (display-only filler always

--- a/src/components/typer/Typer.tsx
+++ b/src/components/typer/Typer.tsx
@@ -198,14 +198,18 @@ export const Typer = (props: TyperProps) => {
         })
     }, [recorder, actualStartTime, subMode, mode, count])
 
-    const cancelRestartRef = useRef(false)
+    // Coalesces the rapid double-restart that fires when settings load right after
+    // mount (default `normal` config → then the persisted mode). Only the *latest*
+    // scheduled restart runs, so its fresh mode/config wins — the old boolean flag
+    // let the first-fired (stale) closure win, which loaded normal text over the
+    // returning grams/practice mode.
+    const restartSeqRef = useRef(0)
     const textRequestRef = useRef(0)
 
     const handleRestart = useCallback((targetLevel?: number) => {
-        cancelRestartRef.current = true;
+        const seq = ++restartSeqRef.current
         setTimeout(() => {
-            if (cancelRestartRef.current) {
-                cancelRestartRef.current = false; // Reset the cancel flag
+            if (seq === restartSeqRef.current) {
                 if (mode !== TestModes.ngrams) syncCharAttempts()
 
                 // A daily challenge uses fixed seeded text — same for every client,

--- a/src/lib/challenge.test.ts
+++ b/src/lib/challenge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { CHALLENGE_WORD_COUNT, challengeDateKey, challengeShareBrag, challengeStreakFromDateKeys, challengeText, shiftChallengeDateKey } from "./challenge"
+import { CHALLENGE_WORD_COUNT, challengeDateKey, challengeShareBrag, challengeStreakFromDateKeys, challengeText, formatCountdown, msUntilNextChallenge, shiftChallengeDateKey } from "./challenge"
 
 const WORDS = "the quick brown fox jumps over a lazy dog and then runs far away home".split(" ")
 
@@ -28,6 +28,21 @@ describe("challengeText", () => {
 
     it("returns empty for an empty corpus", () => {
         expect(challengeText([], "2026-06-16")).toBe("")
+    })
+})
+
+describe("challenge countdown", () => {
+    it("counts down to the next UTC midnight", () => {
+        // 21:00 UTC → 3h to the next 00:00 UTC.
+        expect(msUntilNextChallenge(new Date("2026-06-16T21:00:00.000Z"))).toBe(3 * 3600 * 1000)
+        // One second before rollover.
+        expect(msUntilNextChallenge(new Date("2026-06-16T23:59:59.000Z"))).toBe(1000)
+    })
+
+    it("formats as Hh MMm SSs, zero-padded and clamped", () => {
+        expect(formatCountdown(5 * 3600_000 + 7 * 60_000 + 3_000)).toBe("5h 07m 03s")
+        expect(formatCountdown(0)).toBe("0h 00m 00s")
+        expect(formatCountdown(-1000)).toBe("0h 00m 00s")
     })
 })
 

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -38,6 +38,23 @@ export function challengeDateKey(now: Date, utcOffsetMinutes = 0): string {
     return dayKey(now, utcOffsetMinutes)
 }
 
+// Milliseconds until the challenge rolls over. The day boundary is UTC midnight
+// (synced: same countdown for everyone, matching the UTC dateKey), so this is the
+// gap to the next 00:00 UTC.
+export function msUntilNextChallenge(now: Date): number {
+    const next = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
+    return next - now.getTime()
+}
+
+// A countdown as "Hh MMm SSs" (e.g. "5h 07m 03s"), clamped at zero.
+export function formatCountdown(ms: number): string {
+    const total = Math.max(0, Math.floor(ms / 1000))
+    const h = Math.floor(total / 3600)
+    const m = Math.floor((total % 3600) / 60)
+    const s = total % 60
+    return `${h}h ${String(m).padStart(2, "0")}m ${String(s).padStart(2, "0")}s`
+}
+
 export function shiftChallengeDateKey(dateKey: string, days: number): string {
     const date = new Date(`${dateKey}T00:00:00.000Z`)
     if (Number.isNaN(date.getTime())) return dateKey

--- a/src/pages/challenge.tsx
+++ b/src/pages/challenge.tsx
@@ -10,7 +10,7 @@ import { typingFocusFadeClass } from "~/components/typer/typingFocus";
 import { TestModes, TestSubModes } from "~/components/typer/types";
 import { getWords } from "~/components/typer/utils";
 import { DEFAULT_TEST_SETTINGS } from "~/hooks/useTestSettings";
-import { challengeDateKey, challengeShareBrag, challengeText } from "~/lib/challenge";
+import { challengeDateKey, challengeShareBrag, challengeText, formatCountdown, msUntilNextChallenge } from "~/lib/challenge";
 import { recordLocalChallenge } from "~/lib/challengeHistory";
 import { isAnyModalOpen } from "~/lib/modals";
 import { api } from "~/utils/api";
@@ -99,6 +99,9 @@ const Challenge: NextPage = () => {
     const [shareUrl, setShareUrl] = useState<string | undefined>(undefined);
     const [isSavingScore, setIsSavingScore] = useState(false);
     const [dateKey, setDateKey] = useState<string | null>(null);
+    // Ticks once a second to drive the "new challenge in …" countdown. Null until
+    // mounted so the server/first-client render agree (no hydration mismatch).
+    const [nowTs, setNowTs] = useState<number | null>(null);
     const charAttemptsRef = useRef<Map<string, { attempts: number; correct: number }>>(new Map());
     // True while the result card is on screen for the current attempt — guards the
     // async save upgrade from re-showing the card after the user already restarted.
@@ -107,8 +110,18 @@ const Challenge: NextPage = () => {
     const createShare = api.scoreShare.create.useMutation();
 
     useEffect(() => {
-        setDateKey(challengeDateKey(new Date(), -new Date().getTimezoneOffset()));
+        // Synced UTC: one text, one leaderboard, one countdown for everyone. The day
+        // rolls over at UTC midnight worldwide (not local midnight), so "everyone
+        // types the same text today" is literally true.
+        setDateKey(challengeDateKey(new Date()));
     }, []);
+
+    useEffect(() => {
+        setNowTs(Date.now());
+        const id = setInterval(() => setNowTs(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, []);
+    const resetsIn = nowTs !== null ? formatCountdown(msUntilNextChallenge(new Date(nowTs))) : null;
 
     // Today's challenge is deterministic seeded text from the local calendar day.
     // Every client gets the same 30s text with no network or scheduled job.
@@ -125,10 +138,15 @@ const Challenge: NextPage = () => {
         cardActiveRef.current = true;
         // Record the challenge and refresh the boards once — on the first (eager)
         // report — not again when the save settles.
-        if (!result.persisted && dateKey) {
+        if (dateKey) {
             // Store net (the canonical WPM) so the guest challenge status/board
-            // matches the signed-in path.
-            recordLocalChallenge({ dateKey, wpm: result.netWpm, accuracy: result.accuracy, t: Date.now() });
+            // matches the signed-in path — guests only ever report eagerly.
+            if (!result.persisted) {
+                recordLocalChallenge({ dateKey, wpm: result.netWpm, accuracy: result.accuracy, t: Date.now() });
+            }
+            // Refresh on every report: a signed-in user's score only lands in the DB
+            // on the persisted upgrade, so the boards must refetch then too —
+            // otherwise a replay's new score never shows until a full reload.
             void utils.test.getDailyChallengeStatus.invalidate({ dateKey });
             void utils.test.getDailyChallengeBoards.invalidate({ dateKey, limit: 10 });
         }
@@ -238,6 +256,11 @@ const Challenge: NextPage = () => {
                             <div data-testid="challenge-header" className={typingFocusFadeClass(typingFocused, "mx-auto mb-4 w-full max-w-screen-xl text-center")}>
                                 <h1 className="font-mono text-2xl font-bold tracking-tight">Daily Challenge</h1>
                                 <p className="text-sm text-base-content/60">{dateKey} / 30s / everyone types the same text today</p>
+                                {resetsIn &&
+                                    <p data-testid="challenge-countdown" className="mt-1 font-mono text-xs text-base-content/45">
+                                        new challenge in {resetsIn}
+                                    </p>
+                                }
                             </div>
                         }
                         <Typer

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -70,8 +70,11 @@ const Home: NextPage = () => {
   const [currentKey, setCurrentKey] = useState("")
   const [typingFocused, setTypingFocused] = useState(false)
   // Practice: the shift-layer toggle lives in the settings line but drives the
-  // keyboard board below the test, so the page holds it.
+  // keyboard board below the test, so the page holds it. Holding physical Shift
+  // peeks the layer (release returns to the sticky toggle) — lifted here so the
+  // settings-line "shift on/off" label reflects the peek too, not just the board.
   const [shiftToggle, setShiftToggle] = useState(false)
+  const [shiftHeld, setShiftHeld] = useState(false)
   const dispatch = useDispatch()
   const currentKeyRef = useRef("")
   const [attemptVersion, setAttemptVersion] = useState(0)
@@ -170,6 +173,22 @@ const Home: NextPage = () => {
       // Corrupt entry — ignore.
     }
   }, [])
+
+  useEffect(() => {
+    if (mode !== TestModes.practice) return
+    const onDown = (e: KeyboardEvent) => { if (e.key === "Shift" && !e.repeat) setShiftHeld(true) }
+    const onUp = (e: KeyboardEvent) => { if (e.key === "Shift") setShiftHeld(false) }
+    const clear = () => setShiftHeld(false)
+    window.addEventListener("keydown", onDown)
+    window.addEventListener("keyup", onUp)
+    window.addEventListener("blur", clear)
+    return () => {
+      window.removeEventListener("keydown", onDown)
+      window.removeEventListener("keyup", onUp)
+      window.removeEventListener("blur", clear)
+    }
+  }, [mode])
+  const shiftLayer = shiftToggle || shiftHeld
 
   const onKeyChange = (key: string) => {
     if (currentKeyRef.current === key) return
@@ -612,7 +631,7 @@ const Home: NextPage = () => {
               gramAccuracyThreshold={gramAccuracyThreshold}
               punctuation={punctuation}
               capitals={capitals}
-              shiftLayer={shiftToggle}
+              shiftLayer={shiftLayer}
               onToggleShift={() => setShiftToggle((on) => !on)}
               onSmartDrill={handleSmartDrill}
               setCount={setCount}
@@ -728,7 +747,7 @@ const Home: NextPage = () => {
         }
         {!completedScore && shouldShowHomeKeyboard &&
           <div data-testid="typing-focus-home-keyboard" className="min-h-[11rem] md:min-h-[15.25rem]">
-            <Keyboard mode={mode} currentKey={currentKey} selectedKeys={selectedKeys} setSelectedKeys={setSelectedKeys} charAttemptsRef={charAttemptsRef} baseAttemptsRef={persistedAttemptsRef} attemptVersion={attemptVersion} shiftToggle={shiftToggle} />
+            <Keyboard mode={mode} currentKey={currentKey} selectedKeys={selectedKeys} setSelectedKeys={setSelectedKeys} charAttemptsRef={charAttemptsRef} baseAttemptsRef={persistedAttemptsRef} attemptVersion={attemptVersion} shiftToggle={shiftLayer} />
           </div>
         }
       </div>

--- a/tests/e2e/challenge.spec.ts
+++ b/tests/e2e/challenge.spec.ts
@@ -106,6 +106,7 @@ test.describe("daily challenge", () => {
 
     await expect(page.getByTestId("challenge-header")).toBeVisible();
     await expect(page.getByText(/everyone types the same text today/)).toBeVisible();
+    await expect(page.getByTestId("challenge-countdown")).toContainText(/new challenge in \d+h \d\dm \d\ds/);
     await expect(page.locator("#words .char").first()).toBeVisible();
     await expect(page.getByTestId("daily-challenge-boards")).toBeVisible();
     await expect(page.getByText("Fastest Today")).toBeVisible();

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -71,6 +71,25 @@ test.describe("home typing test", () => {
     await expect(page.locator("#c0")).not.toHaveClass(/text-base-300/);
   });
 
+  test("returning to a persisted grams mode loads grams text, not normal words", async ({ page }) => {
+    // Regression: settings load in an effect after mount, so the typer first mounts
+    // in the default (normal) mode and must switch. The restart coalescing has to
+    // keep the *latest* (grams) config — the old first-fired-wins flag loaded the
+    // 500-char normal buffer over the returning grams drill (mode 2 = ngrams).
+    await page.addInitScript(() => {
+      window.localStorage.setItem("typecafe:testSettings", JSON.stringify({ mode: 2 }));
+    });
+    await page.goto("/");
+    await expect(page.locator("#typer")).toBeVisible();
+    await expect(page.locator("#words .char").first()).toBeVisible();
+    // Grams renders its own progress bar + running-average stat; normal never does.
+    await expect(page.getByTestId("gram-progress")).toBeVisible();
+    await expect(page.getByTestId("stat-avg")).toBeVisible();
+    // A gram is a couple of characters; the normal buffer would be ~500.
+    const text = (await page.locator("#words").innerText()).trim();
+    expect(text.length).toBeLessThan(20);
+  });
+
   test("Tab+Space restarts the test (Tab swallows the chord key)", async ({ page }) => {
     await gotoHome(page);
 

--- a/tests/e2e/screenshots.spec.ts
+++ b/tests/e2e/screenshots.spec.ts
@@ -274,12 +274,17 @@ test.describe("screenshot tour", () => {
     await capture(page, testInfo, "32-practice-keyboard-analytics");
 
     // Shift layer: holding Shift peeks the shifted twins (; → :, / → ?); releasing
-    // returns to base. The layout never moves.
+    // returns to base. The layout never moves. The settings-line label tracks the
+    // peek too, not just the board.
+    const shiftLabel = page.getByRole("button", { name: "Show shifted keys (capitals and symbols)" });
+    await expect(shiftLabel).toContainText("shift off");
     await page.keyboard.down("Shift");
     await expect(keyboardKey(":")).toHaveCount(1);
     await expect(keyboardKey(";")).toHaveCount(0);
+    await expect(shiftLabel).toContainText("shift on");
     await page.keyboard.up("Shift");
     await expect(keyboardKey(";")).toHaveCount(1);
+    await expect(shiftLabel).toContainText("shift off");
 
     // The sticky toggle button does the same, but stays put (touch / lingering).
     await page.getByRole("button", { name: "Show shifted keys (capitals and symbols)" }).click();
@@ -608,6 +613,7 @@ test.describe("screenshot tour", () => {
     await mockTrpc(page);
     await page.goto("/challenge");
     await expect(page.getByTestId("challenge-header")).toBeVisible();
+    await expect(page.getByTestId("challenge-countdown")).toContainText(/new challenge in/);
     await expect(page.locator("#words .char").first()).toBeVisible();
     const boards = page.getByTestId("daily-challenge-boards");
     await expect(boards).toBeVisible();


### PR DESCRIPTION
- switching back to grams mode from different page loads normal text not grams text, actually this happens for all modes practice does it too
- restarting after daily challenge should update leaderboards
- Add timers for how long is left in daily challenge
- Decide to use synced time or per timezone