### PR TITLE
fix(typer): descenders no longer clip and underlines stay whole under…

### DIFF
--- a/src/components/typer/Text.tsx
+++ b/src/components/typer/Text.tsx
@@ -557,7 +557,10 @@ export const Text = memo(function Text(props: TextProps) {
             <div className="flex w-full justify-center">
                 <div className="flex min-w-0 max-w-full flex-col">
                     {counter}
-                    <div className="flex w-full max-h-[6.6rem] flex-wrap overflow-y-hidden no-scrollbar scroll-smooth font-mono select-none sm:max-h-[9rem]" id="words" ref={typerRef}>
+                    {/* max-h is 3 line-heights + a sliver: the extra clears the bottom
+                        line's descenders (which dip past the line box) while staying
+                        inside the next line's blank half-leading, so no 4th line peeks. */}
+                    <div className="flex w-full max-h-[6.85rem] flex-wrap overflow-y-hidden no-scrollbar scroll-smooth font-mono select-none sm:max-h-[9.3rem]" id="words" ref={typerRef}>
                         <div
                             className="max-w-full"
                             ref={textContainerRef}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -228,6 +228,11 @@ button:disabled,
 .incorrect-char {
     color: var(--error-color);
     text-decoration: underline;
+    /* Descenders (y, g, p…) otherwise break the underline via skip-ink and, at
+       the default baseline position, the line cuts through the tail; drop it
+       just under the glyph and keep it continuous. */
+    text-underline-position: under;
+    text-decoration-skip-ink: none;
 }
 
 .typing-focus-global-fade {


### PR DESCRIPTION
… y/g

Two visual bugs on the typing text:
- Incorrect-char underlines broke apart at descenders (y, g, p): the default text-decoration-skip-ink cut the line where the glyph tail crossed it. Set skip-ink: none and underline-position: under so the line sits just below the glyph and runs continuous.
- The bottom line's descenders were sheared off by #words' overflow-y-hidden window (max-h was an exact 3x line-height). Bumped max-h a sliver so descender ink clears, staying inside the next line's blank half-leading — no 4th line peeks.

Verified by driving the real typer (wrong keys for underlines; scrolled past 3 lines for descenders) and diffing before/after screenshots. Unit suite (434) and home e2e (36) green.