### PR TITLE
feat(share): consolidate score sharing into one in-place dropdown

### DIFF
--- a/src/components/scores/ShareableScoreCard.tsx
+++ b/src/components/scores/ShareableScoreCard.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
-import { type CSSProperties, useEffect, useId, useMemo, useRef, useState } from "react";
+import { type CSSProperties, type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
+
+import { ToolbarMenu } from "~/components/typer/config/ToolbarMenu";
 
 import { TestModes, TestSubModes } from "~/components/typer/types";
 import { ShareableScoreImage } from "./ShareableScoreImage";
@@ -264,13 +266,60 @@ function ShareIcon() {
   );
 }
 
-function ScreenshotIcon() {
+function ChevronDownIcon() {
   return (
-    <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="M7 7h.01M17 7h.01M7 17h.01M17 17h.01" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M9 3H5a2 2 0 0 0-2 2v4M15 3h4a2 2 0 0 1 2 2v4M9 21H5a2 2 0 0 1-2-2v-4M15 21h4a2 2 0 0 0 2-2v-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M9 12h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    <svg className="h-3.5 w-3.5 shrink-0" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="m6 9 6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
+  );
+}
+
+const shareMenuItemClass =
+  "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary";
+
+// A link-out share target (X, Reddit). Rendered as an inert row with a trailing
+// spinner until the share URL is minted, then swapped for a real anchor — so the
+// click that opens the tab is a fresh user gesture (no popup-blocker fight).
+function ShareMenuLink(props: { href?: string; loading: boolean; icon: ReactNode; label: string; onSelect: () => void }) {
+  if (!props.href) {
+    return (
+      <span role="menuitem" aria-disabled="true" className={`${shareMenuItemClass} cursor-default text-base-content/45`}>
+        {props.icon}
+        <span>{props.label}</span>
+        {props.loading && <span className="ml-auto"><Spinner /></span>}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      role="menuitem"
+      href={props.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={props.onSelect}
+      className={`${shareMenuItemClass} text-base-content hover:bg-base-300`}
+    >
+      {props.icon}
+      <span>{props.label}</span>
+    </a>
+  );
+}
+
+function ShareMenuButton(props: { onClick: () => void; disabled?: boolean; loading?: boolean; icon: ReactNode; label: string; testId?: string }) {
+  return (
+    <button
+      role="menuitem"
+      type="button"
+      data-testid={props.testId}
+      onClick={props.onClick}
+      disabled={props.disabled}
+      className={`${shareMenuItemClass} ${props.disabled ? "cursor-default text-base-content/45" : "text-base-content hover:bg-base-300"}`}
+    >
+      {props.icon}
+      <span>{props.label}</span>
+      {props.loading && <span className="ml-auto"><Spinner /></span>}
+    </button>
   );
 }
 
@@ -614,6 +663,11 @@ export function ShareableScoreCard(props: ShareableScoreCardProps) {
   const showSignInCta = !readonly && !shareUrl && !canCreateShare && !isSaving && !!signInHtmlFor;
   const [linkState, setLinkState] = useState<ActionState>("idle");
   const [imageState, setImageState] = useState<ActionState>("idle");
+  // The share menu mints the link as soon as it opens; the link-out targets stay
+  // inert (spinners) until the URL exists, then become live anchors. Failed mints
+  // surface a retry rather than spinning forever.
+  const [shareMenuOpen, setShareMenuOpen] = useState(false);
+  const [shareFailed, setShareFailed] = useState(false);
   // Detected client-side to avoid a hydration mismatch (the server has no
   // navigator). Gates the native-share button so tests without Web Share stay
   // deterministic (the X/Reddit links always render).
@@ -626,8 +680,6 @@ export function ShareableScoreCard(props: ShareableScoreCardProps) {
   const scoreCardRef = useRef<HTMLDivElement | null>(null);
   const shareImageRef = useRef<HTMLDivElement | null>(null);
   const modeText = formatModeText(score);
-  const shareLoading = isCreatingShare || isSaving;
-  const shareButtonLabel = isSaving ? "Saving..." : isCreatingShare ? "Creating..." : linkState === "copied" ? "Link copied" : "Share Score";
   const screenshotButtonLabel = imageState === "copied" ? "Screenshot copied" : imageState === "downloaded" ? "Image downloaded" : "Copy Screenshot";
 
   const scheduleReset = () => {
@@ -654,6 +706,24 @@ export function ShareableScoreCard(props: ShareableScoreCardProps) {
     } finally {
       scheduleReset();
     }
+  };
+
+  // Mint the share URL in the background the moment the menu opens. Guarded so a
+  // reopen (or the already-minted readonly case) never creates a duplicate row.
+  const startMint = async () => {
+    if (shareUrl || isCreatingShare) return;
+    setShareFailed(false);
+    try {
+      const url = await onCreateShare?.();
+      if (!url) setShareFailed(true);
+    } catch {
+      setShareFailed(true);
+    }
+  };
+
+  const openShareMenu = () => {
+    setShareMenuOpen(true);
+    void startMint();
   };
 
   const handleNativeShare = async () => {
@@ -716,7 +786,10 @@ export function ShareableScoreCard(props: ShareableScoreCardProps) {
         aria-label="Typing test results"
         className="rounded-xl border border-base-content/15 bg-base-200 p-5 text-base-content shadow-2xl shadow-base-300/40 sm:p-6"
       >
-        <div className="score-reveal flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+        {/* relative z-30: each .score-reveal is its own stacking context (opacity/
+            transform), so without this the share dropdown would paint behind the
+            metric cards below it. */}
+        <div className="score-reveal relative z-30 flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-4">
             <div>
               <div className="mb-2 flex flex-wrap items-center gap-2">
@@ -833,30 +906,78 @@ export function ShareableScoreCard(props: ShareableScoreCardProps) {
                 <span>Sign in to save &amp; share</span>
               </label>
               : (!readonly || shareUrl) ?
-              <button
-                className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-content transition hover:opacity-85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-50"
-                type="button"
-                disabled={shareLoading || (!shareUrl && !canCreateShare)}
-                onClick={handleCopyLink}
-                aria-label={shareButtonLabel}
-                title={isSaving ? "Saving your score" : isCreatingShare ? "Creating share link" : linkState === "copied" ? "Share link copied" : "Copy share score link"}
+              <ToolbarMenu
+                open={shareMenuOpen}
+                onClose={() => setShareMenuOpen(false)}
+                testId="share-menu"
+                widthClassName="min-w-56"
+                trigger={
+                  <button
+                    className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-content transition hover:opacity-85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-50"
+                    type="button"
+                    disabled={isSaving || (!shareUrl && !canCreateShare)}
+                    onClick={() => (shareMenuOpen ? setShareMenuOpen(false) : openShareMenu())}
+                    aria-haspopup="menu"
+                    aria-expanded={shareMenuOpen}
+                    aria-label="Share Score"
+                    title={isSaving ? "Saving your score" : "Share your score"}
+                  >
+                    {isSaving ? <Spinner /> : <ShareIcon />}
+                    <span>{isSaving ? "Saving..." : "Share Score"}</span>
+                    <ChevronDownIcon />
+                  </button>
+                }
               >
-                {shareLoading ? <Spinner /> : <ShareIcon />}
-                <span>{shareButtonLabel}</span>
-              </button>
+                <div role="menu" className="flex flex-col gap-1">
+                  <ShareMenuButton
+                    icon={<i className="fa-solid fa-link w-4 text-center" aria-hidden="true" />}
+                    label={linkState === "copied" ? "Link copied" : "Copy link"}
+                    onClick={handleCopyLink}
+                    disabled={!shareUrl}
+                    loading={!shareUrl && !shareFailed}
+                  />
+                  <ShareMenuLink
+                    icon={<i className="fa-brands fa-x-twitter w-4 text-center" aria-hidden="true" />}
+                    label="Share on X"
+                    href={shareUrl ? tweetHref(shareText, shareUrl) : undefined}
+                    loading={!shareUrl && !shareFailed}
+                    onSelect={() => setShareMenuOpen(false)}
+                  />
+                  <ShareMenuLink
+                    icon={<i className="fa-brands fa-reddit-alien w-4 text-center" aria-hidden="true" />}
+                    label="Share on Reddit"
+                    href={shareUrl ? redditHref(shareText, shareUrl) : undefined}
+                    loading={!shareUrl && !shareFailed}
+                    onSelect={() => setShareMenuOpen(false)}
+                  />
+                  {canNativeShare &&
+                    <ShareMenuButton
+                      icon={<i className="fa-solid fa-share-nodes w-4 text-center" aria-hidden="true" />}
+                      label="Share via device"
+                      onClick={() => { void handleNativeShare(); setShareMenuOpen(false); }}
+                      disabled={!shareUrl}
+                      loading={!shareUrl && !shareFailed}
+                    />
+                  }
+                  {shareFailed &&
+                    <ShareMenuButton
+                      icon={<i className="fa-solid fa-rotate-right w-4 text-center" aria-hidden="true" />}
+                      label="Couldn't create link — Retry"
+                      onClick={() => void startMint()}
+                    />
+                  }
+                  <div className="my-1 border-t border-base-content/10" />
+                  <ShareMenuButton
+                    testId="share-menu-screenshot"
+                    icon={<i className="fa-solid fa-image w-4 text-center" aria-hidden="true" />}
+                    label={screenshotButtonLabel}
+                    onClick={handleCopyImage}
+                  />
+                </div>
+              </ToolbarMenu>
               :
               null
             }
-            <button
-              className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md bg-secondary px-4 py-2 text-sm font-semibold text-secondary-content transition hover:opacity-85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
-              type="button"
-              onClick={handleCopyImage}
-              aria-label={screenshotButtonLabel}
-              title={imageState === "copied" ? "Score screenshot copied" : imageState === "downloaded" ? "Score image downloaded" : "Copy score screenshot image"}
-            >
-              <ScreenshotIcon />
-              <span>{screenshotButtonLabel}</span>
-            </button>
           </div>
         </div>
 
@@ -903,43 +1024,6 @@ export function ShareableScoreCard(props: ShareableScoreCardProps) {
           </div>
         </div>
       </div>
-
-      {shareUrl &&
-        <div data-testid="share-targets" className="flex flex-wrap items-center gap-2 pt-3">
-          <span className="text-sm text-base-content/60">Share to</span>
-          {canNativeShare &&
-            <button
-              type="button"
-              onClick={handleNativeShare}
-              className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md border border-base-content/15 bg-base-100/50 px-3 py-1.5 text-sm font-semibold text-base-content transition hover:bg-base-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-              aria-label="Share via your device"
-            >
-              <ShareIcon />
-              <span>Share</span>
-            </button>
-          }
-          <a
-            href={tweetHref(shareText, shareUrl)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md border border-base-content/15 bg-base-100/50 px-3 py-1.5 text-sm font-semibold text-base-content transition hover:bg-base-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-            aria-label="Share on X"
-          >
-            <i className="fa-brands fa-x-twitter" aria-hidden="true" />
-            <span>X</span>
-          </a>
-          <a
-            href={redditHref(shareText, shareUrl)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md border border-base-content/15 bg-base-100/50 px-3 py-1.5 text-sm font-semibold text-base-content transition hover:bg-base-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-            aria-label="Share on Reddit"
-          >
-            <i className="fa-brands fa-reddit-alien" aria-hidden="true" />
-            <span>Reddit</span>
-          </a>
-        </div>
-      }
 
       <div aria-live="polite" role="status" className="min-h-8 pt-3 text-sm">
         {linkState === "unsupported" ?

--- a/tests/e2e/challenge.spec.ts
+++ b/tests/e2e/challenge.spec.ts
@@ -168,8 +168,10 @@ test.describe("daily challenge", () => {
     await expect(page.getByTestId("avg-delta")).toContainText("3.2 WPM over your 30-day average");
 
     await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    // Copy link is inert until the share URL is minted; the click auto-waits for it.
+    await page.getByTestId("share-menu").getByRole("menuitem", { name: "Copy link" }).click();
 
-    await expect(page.getByRole("button", { name: "Link copied" })).toBeVisible();
+    await expect(page.getByTestId("share-menu").getByRole("menuitem", { name: "Link copied" })).toBeVisible();
     await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("clipboard:text"))).toBe("http://127.0.0.1:3000/score/share-test-score");
     expect(procedures.map(({ procedure }) => procedure)).toContain("test.create");
     expect(procedures.map(({ procedure }) => procedure)).toContain("scoreShare.create");

--- a/tests/e2e/screenshots.spec.ts
+++ b/tests/e2e/screenshots.spec.ts
@@ -808,6 +808,11 @@ test.describe("screenshot tour", () => {
     // The persisted delta line rides the shared snapshot (§3.3 slice 2).
     await expect(page.getByTestId("avg-delta")).toContainText("over your 30-day average");
     await capture(page, testInfo, "18-shared-score");
+
+    // The share menu: one entry point, all targets revealed together in place.
+    await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    await expect(page.getByTestId("share-menu").getByRole("menuitem", { name: "Share on X" })).toBeVisible();
+    await capture(page, testInfo, "18b-shared-score-share-menu");
   });
 
   test("shared score page (guest, no account)", async ({ page }, testInfo) => {

--- a/tests/e2e/shared-score.spec.ts
+++ b/tests/e2e/shared-score.spec.ts
@@ -130,8 +130,9 @@ test.describe("shared scores", () => {
     await expect(page.getByTestId("beat-heatmap-comparison")).toBeVisible();
 
     await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    await page.getByTestId("share-menu").getByRole("menuitem", { name: "Copy link" }).click();
 
-    await expect(page.getByRole("button", { name: "Link copied" })).toBeVisible();
+    await expect(page.getByTestId("share-menu").getByRole("menuitem", { name: "Link copied" })).toBeVisible();
     await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("clipboard:text"))).toBe("http://127.0.0.1:3000/score/beat-run-share");
 
     const createBeatRun = procedures.find(({ procedure }) => procedure === "scoreShare.createBeatRun");
@@ -165,8 +166,9 @@ test.describe("shared scores", () => {
     await expect(page.getByTestId("score-screenshot-card").getByText("Faster than 72% of similar starters")).toBeVisible();
     await expect(page.locator("#words")).toBeHidden();
     await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    await page.getByTestId("share-menu").getByRole("menuitem", { name: "Copy link" }).click();
 
-    await expect(page.getByRole("button", { name: "Link copied" })).toBeVisible();
+    await expect(page.getByTestId("share-menu").getByRole("menuitem", { name: "Link copied" })).toBeVisible();
     await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("clipboard:text"))).toBe("http://127.0.0.1:3000/score/share-test-score");
     expect(procedures).toContain("test.create");
     expect(procedures).toContain("scoreShare.create");
@@ -186,8 +188,9 @@ test.describe("shared scores", () => {
     // The guest sees a real Share button, not a "Sign in to save & share" wall.
     await expect(page.getByRole("button", { name: "Sign in to save & share" })).toHaveCount(0);
     await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    await page.getByTestId("share-menu").getByRole("menuitem", { name: "Copy link" }).click();
 
-    await expect(page.getByRole("button", { name: "Link copied" })).toBeVisible();
+    await expect(page.getByTestId("share-menu").getByRole("menuitem", { name: "Link copied" })).toBeVisible();
     await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("clipboard:text"))).toBe("http://127.0.0.1:3000/score/guest-score-share");
     // Guests take the snapshot-only mint, never the account-linked create.
     expect(procedures).toContain("scoreShare.createGuestScore");
@@ -200,17 +203,20 @@ test.describe("shared scores", () => {
     await page.goto("/score/share-test-score");
     await expect(page.getByTestId("score-screenshot-card")).toBeVisible();
 
-    const targets = page.getByTestId("share-targets");
-    await expect(targets).toBeVisible();
+    // On a shared page the URL already exists, so opening the menu shows the X and
+    // Reddit targets as live anchors immediately (no minting round-trip).
+    await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    const menu = page.getByTestId("share-menu");
+    await expect(menu).toBeVisible();
 
-    const x = targets.getByRole("link", { name: "Share on X" });
+    const x = menu.getByRole("menuitem", { name: "Share on X" });
     await expect(x).toHaveAttribute("href", /twitter\.com\/intent\/tweet/);
     // The share URL is carried through as the `url` param.
     await expect(x).toHaveAttribute("href", /score%2Fshare-test-score/);
     // Delta-forward text: "(+4.1 vs my 30-day average)" → the + encodes to %2B.
     await expect(x).toHaveAttribute("href", /%2B4\.1/);
 
-    const reddit = targets.getByRole("link", { name: "Share on Reddit" });
+    const reddit = menu.getByRole("menuitem", { name: "Share on Reddit" });
     await expect(reddit).toHaveAttribute("href", /reddit\.com\/submit/);
     await expect(reddit).toHaveAttribute("href", /score%2Fshare-test-score/);
   });
@@ -270,9 +276,10 @@ test.describe("shared scores", () => {
     // full results dashboard.
     const deviceScaleFactor = await page.evaluate(() => window.devicePixelRatio || 1);
 
-    await page.getByRole("button", { name: "Copy Screenshot" }).click({ force: true });
+    await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    await page.getByTestId("share-menu-screenshot").click();
 
-    await expect(page.getByRole("button", { name: "Screenshot copied" })).toBeVisible();
+    await expect(page.getByTestId("share-menu-screenshot")).toContainText("Screenshot copied");
     await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("clipboard:item-count"))).toBe("1");
     await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("clipboard:item-types"))).toBe("image/png");
     const imageWidth = Number(await page.evaluate(() => window.localStorage.getItem("clipboard:image-width")));
@@ -293,11 +300,12 @@ test.describe("shared scores", () => {
     await expect(page.getByTestId("score-screenshot-card")).toBeVisible();
 
     const downloadPromise = page.waitForEvent("download");
-    await page.getByRole("button", { name: "Copy Screenshot" }).click({ force: true });
+    await page.getByRole("button", { name: "Share Score" }).click({ force: true });
+    await page.getByTestId("share-menu-screenshot").click();
 
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toBe("typecafe-score.png");
-    await expect(page.getByRole("button", { name: "Image downloaded" })).toBeVisible();
+    await expect(page.getByTestId("share-menu-screenshot")).toContainText("Image downloaded");
   });
 
   test("exposes an OG image and per-score meta tags for unfurls", async ({ page }) => {


### PR DESCRIPTION
The X/Reddit/native targets were hidden until a "Share Score" click and then rendered at the very bottom of the card — far from the trigger and undiscoverable. Replace the separate copy-link button + bottom target row with a single Share dropdown in the action bar.

Opening the menu mints the share link in the background; the link-out targets stay inert (spinners) until the URL exists, then become live anchors — so the tab-opening click is a fresh user gesture and never trips popup blockers. Failed mints surface a retry instead of spinning forever. Copy link / native share / copy screenshot live in the same menu.

Also fix a stacking bug: each .score-reveal section is its own stacking context (opacity/transform), so the dropdown painted behind the metric cards below it — pin the header section with relative z-30.

Verified: npx playwright test shared-score + challenge (33 passed, both projects), screenshot tour regenerated (18b-shared-score-share-menu), tsc + eslint clean.